### PR TITLE
Added sorting on duplicate_count

### DIFF
--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -564,7 +564,7 @@ class Backend(Database):
               FROM alerts, UNNEST (service) svc
              WHERE {where}
           GROUP BY {group}
-          ORDER BY count DESC
+          ORDER BY count DESC, duplicate_count DESC
         """.format(where=query.where, group=group)
         return [
             {
@@ -590,7 +590,7 @@ class Backend(Database):
               FROM topn, UNNEST (service) svc, UNNEST (history) hist
              WHERE hist.type='severity'
           GROUP BY topn.{group}
-          ORDER BY count DESC
+          ORDER BY count DESC, duplicate_count DESC
         """.format(where=query.where, group=group)
         return [
             {


### PR DESCRIPTION
Current sorting is on count only, so alerts with high duplicate_count might or might not be listed. This commit addresses that.